### PR TITLE
Fix for explode caused due to passing the color encoded string to mustParseHex.

### DIFF
--- a/exploitaben/exploitaben.py
+++ b/exploitaben/exploitaben.py
@@ -106,6 +106,8 @@ def main(argv):
     parser.add_option('-P', '--attach-name', type='string', dest='attach_name', metavar='PROCESSNAME', help='Specify a process to attach to by name.', default=None)
     parser.add_option('-w', '--attach-wait', action='store_true', dest='attach_wait', help='Wait for the next process to launch when attaching to a process by name.', default=False)
     parser.add_option('-O', '--show-output', action='store_true', dest='show_output', help='Print the captured stdout/stderr from the target at exit.', default=False)
+    parser.add_option('-N', '--no-color', action='store_true', dest='no_color', help='Print the output without color encoding', default=False)
+    
     try:
         (options, args) = parser.parse_args(argv)
     except:
@@ -237,7 +239,7 @@ def main(argv):
                                         except:
                                             print "<disassembly failed>"
                                         
-                                        analyzer = lldbx86.Analyzer(target)
+                                        analyzer = lldbx86.Analyzer(target,options.no_color)
                                         
                                         # will fall back to uncolorized when termcolors is not available
                                         registers = analyzer.prettyRegisters()

--- a/exploitaben/lib/analyzers/x86_lldb.py
+++ b/exploitaben/lib/analyzers/x86_lldb.py
@@ -133,7 +133,11 @@ class Analyzer(object):
     # LLDB standalone tool using the python/SWIG API. This has both good and
     # bad implications, but it's a lot easier to write. Hopefully it can still
     # be folded back into mainline somehow.
-    def __init__(self, target):
+    def __init__(self, target, no_color):
+        global colored
+        if no_color:
+            def colored(s, color):
+                return s
         self.target = target
         self.stack_huge = None
         self.process = target.process

--- a/francis.go
+++ b/francis.go
@@ -127,6 +127,12 @@ LLDB OUTPUT:
 }
 
 func mustParseHex(s string, die func()) (n uint64) {
+	// registers here are coming as colored coded cause of exploitaben's pretty print, and strconv.ParseUint fails
+	// example: 0x000000000000fff4 is causing
+	// strconv.ParseUint: parsing "\x1b[36m0x000000000000fff4\x1b[0m": invalid syntax
+
+	r := regexp.MustCompile("\x1b[^m]*m")
+	s = r.ReplaceAllString(s, "")	
 	n, err := strconv.ParseUint(s, 0, 64)
 	if err != nil {
 		die()

--- a/francis.go
+++ b/francis.go
@@ -127,12 +127,7 @@ LLDB OUTPUT:
 }
 
 func mustParseHex(s string, die func()) (n uint64) {
-	// registers here are coming as colored coded cause of exploitaben's pretty print, and strconv.ParseUint fails
-	// example: 0x000000000000fff4 is causing
-	// strconv.ParseUint: parsing "\x1b[36m0x000000000000fff4\x1b[0m": invalid syntax
 
-	r := regexp.MustCompile("\x1b[^m]*m")
-	s = r.ReplaceAllString(s, "")	
 	n, err := strconv.ParseUint(s, 0, 64)
 	if err != nil {
 		die()

--- a/run_darwin.go
+++ b/run_darwin.go
@@ -28,6 +28,8 @@ func (e *Engine) Run(command []string, filename string, memlimit, timeout int) (
 	if e.Timeout > 0 {
 		cmdSlice = append(cmdSlice, []string{"-t", strconv.Itoa(e.Timeout)}...)
 	}
+	// This gets output from exploitaben without color encoding
+	cmdSlice = append(cmdSlice,"-N")
 	cmdSlice = append(cmdSlice, "--")
 	cmdSlice = append(cmdSlice, command...)
 	cmdStr := strings.Join(cmdSlice, " ")


### PR DESCRIPTION
```
registers here to mustParseHex function are coming as colored coded cause of exploitaben.py's pretty print, and strconv.ParseUint fails to convert.

example: 0x000000000000fff4 was being passed as "\x1b[36m0x000000000000fff4\x1b[0m" and causing below error

strconv.ParseUint: parsing "\x1b[36m0x000000000000fff4\x1b[0m": invalid syntax
```
